### PR TITLE
Added copy constructor, Bugfix: end and cend iterators

### DIFF
--- a/src/linkedList.cpp
+++ b/src/linkedList.cpp
@@ -18,6 +18,16 @@ LinkedList<T>::LinkedList(size_t count, const T& data) : LinkedList()
     }
 }
 
+template <typename T>
+LinkedList<T>::LinkedList(const LinkedList<T>& origin) : LinkedList()
+{
+    LinkedList<T>::const_iterator it;
+    for (it = origin.cbegin(); it != origin.cend(); ++it)
+    {
+        push_back(*it);
+    }
+}
+
 // Iterator Class
 template <typename T>
 LinkedList<T>::iterator::iterator(const pointer ptr) : node(ptr) {}
@@ -116,13 +126,16 @@ typename LinkedList<T>::iterator LinkedList<T>::begin()
 template <typename T>
 typename LinkedList<T>::const_iterator LinkedList<T>::cend() const
 {
-    return const_iterator(tail->Next());
+    // Prevents segmentation fault if attempt to get tails next node if tail is
+    // is a nullptr. Since tail will always point to a nullptr we can just 
+    // return an iterator to a nullptr
+    return const_iterator(nullptr);
 } 
 
 template <typename T>
 typename LinkedList<T>::iterator LinkedList<T>::end()
 {
-    return iterator(tail->Next());
+    return iterator(nullptr);
 } 
 
 // Modifiers

--- a/src/linkedList.hpp
+++ b/src/linkedList.hpp
@@ -19,9 +19,14 @@ class LinkedList
 {
 public:
     // Constructors
+    /* Default */
     LinkedList();
 
+    /* Fill */
     LinkedList(size_t count, const T& data);
+
+    /* Copy */
+    explicit LinkedList(const LinkedList<T>& origin);
 
 
     // TODO Clear and delete each node in the destructor

--- a/tests/linkedListTest.cpp
+++ b/tests/linkedListTest.cpp
@@ -98,6 +98,23 @@ TEST_CASE("Constructing Linked Lists instances", "[linkedLists], [constructors]"
             REQUIRE(element == 100);
         }
     }
+    SECTION("Copy construction")
+    {
+        LinkedList<int> origin(4, 100);
+        LinkedList<int> copy(origin);
+
+        for (auto& element : copy)
+        {
+            REQUIRE(element == 100);
+        }
+    }
+    SECTION("Copy construction on empty list")
+    {
+        LinkedList<int> origin;
+        LinkedList<int> copy(origin);
+
+        REQUIRE(copy.empty() == true);
+    }
 }
 
 TEST_CASE("Pushing elements to the front of the list", "[linkedLists], [modifiers], [iterators]")


### PR DESCRIPTION
## Proposed changes

Copy constructor will take in a const reference to a instantiated linkedlist object and traverse the original and copy it's values onto its nodes.

both the end and cend iterators will always return a nullptr in a forward linked list, as that is the element past the last node in the list. However, constructing an iterator on the tail->next() method can result in a segfault if tail was never initialized like in an empty list. Therefore, I changed the end and cend getters to return an iterator constructed on a nullptr to prevent a segfault

unit tests have been added, and all tests past locally

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/AlexanderJDupree/LinkedListsCPP/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

