### PR TITLE
Overloaded begin() and end() to return const_iterators, fixed issue 32

### DIFF
--- a/src/linkedList.cpp
+++ b/src/linkedList.cpp
@@ -83,10 +83,16 @@ ITERATORS
 *******************************************************************************/
 
 template <typename T>
-typename LinkedList<T>::const_iterator LinkedList<T>::cbegin() const
+typename LinkedList<T>::const_iterator LinkedList<T>::cbegin() const noexcept
 {
     return const_iterator(head);
 }
+
+template <typename T>
+typename LinkedList<T>::const_iterator LinkedList<T>::begin() const
+{
+    return const_iterator(head);
+} 
 
 template <typename T>
 typename LinkedList<T>::iterator LinkedList<T>::begin()
@@ -95,7 +101,13 @@ typename LinkedList<T>::iterator LinkedList<T>::begin()
 } 
 
 template <typename T>
-typename LinkedList<T>::const_iterator LinkedList<T>::cend() const
+typename LinkedList<T>::const_iterator LinkedList<T>::cend() const noexcept
+{
+    return const_iterator(nullptr);
+}
+
+template <typename T>
+typename LinkedList<T>::const_iterator LinkedList<T>::end() const
 {
     return const_iterator(nullptr);
 } 

--- a/src/linkedList.hpp
+++ b/src/linkedList.hpp
@@ -61,10 +61,12 @@ public:
     ~LinkedList();
 
     /* Iterators */
-    const_iterator cbegin() const;
+    const_iterator cbegin() const noexcept;
+    const_iterator begin() const;
     iterator begin();
 
-    const_iterator cend() const;
+    const_iterator cend() const noexcept;
+    const_iterator end() const;
     iterator end();
 
     /* Modifiers */

--- a/tests/linkedListTest.cpp
+++ b/tests/linkedListTest.cpp
@@ -609,7 +609,6 @@ TEST_CASE("Using iterators for iteration", "[linkedLists], [iterators]")
             REQUIRE(*it == 100);
         }
     }
-/* SEE Issue https://github.com/AlexanderJDupree/LinkedListsCPP/issues/32
     SECTION("Using ranged based for loop on const linkedlist")
     {
         const LinkedList<int> list(5,25);
@@ -619,7 +618,6 @@ TEST_CASE("Using iterators for iteration", "[linkedLists], [iterators]")
             REQUIRE(element == 25);
         }
     }
-*/
 }
 
 TEST_CASE("Using iterator arithmetic on iterators", "[iterators]")


### PR DESCRIPTION
## Proposed changes

The problem outlined in issue #32 required that the begin and end functions be overloaded to return a const_iterator. I added these overloads and unit tests.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/AlexanderJDupree/LinkedListsCPP/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
