### PR TITLE
erase_after function

### DIFF
--- a/include/linear_linked_list.hpp
+++ b/include/linear_linked_list.hpp
@@ -109,6 +109,8 @@ class linear_linked_list
     template <class Compare>
     self_type& merge(self_type& list, Compare&& comp);
 
+    iterator erase_after(iterator pos);
+
     // Removes all items matching target, returns number of items removed
     int remove(const_reference target);
 

--- a/src/linear_linked_list.cpp
+++ b/src/linear_linked_list.cpp
@@ -309,7 +309,7 @@ template <typename T>
 typename linear_linked_list<T>::iterator
 linear_linked_list<T>::erase_after(iterator pos)
 {
-    if(!empty() && tail != head)
+    if(!empty() && pos.node != tail)
     {
         Node* temp = pos.node->next;
         pos.node->next = temp->next;

--- a/src/linear_linked_list.cpp
+++ b/src/linear_linked_list.cpp
@@ -306,6 +306,19 @@ linear_linked_list<T>::merge(Node* self, Node* other, Compare&& comp)
 }
 
 template <typename T>
+typename linear_linked_list<T>::iterator
+linear_linked_list<T>::erase_after(iterator pos)
+{
+    if(!empty() && tail != head)
+    {
+        Node* temp = pos.node->next;
+        pos.node->next = temp->next;
+        delete temp;
+    }
+    return pos;
+}
+
+template <typename T>
 int linear_linked_list<T>::remove(const_reference target)
 {
     // lambda catches target and compares it to each element in the list

--- a/tests/linked_list_test.cpp
+++ b/tests/linked_list_test.cpp
@@ -474,6 +474,15 @@ TEST_CASE("Erasing elements from a list", "[operations], [erase_after]")
             REQUIRE(num == ++i);
         }
     }
+    SECTION("Erasing with the last iterator in the list does nothing")
+    {
+        linear_linked_list<int>::iterator it = list.begin();
+        while(*(++it) != 6);
+
+        list.erase_after(it);
+
+        REQUIRE((list.back() == 6) == (*it == 6));
+    }
 }
 
 TEST_CASE("Removing a specific element from a list", "[operations], [remove]")

--- a/tests/linked_list_test.cpp
+++ b/tests/linked_list_test.cpp
@@ -449,11 +449,38 @@ TEST_CASE("Popping the front element off the list", "[operations], [pop_front]")
     }
 }
 
+TEST_CASE("Erasing elements from a list", "[operations], [erase_after]")
+{
+    linear_linked_list<int> empty_list;
+    linear_linked_list<int> list { 1, 4, 2, 3, 4, 5, 6 };
+
+    SECTION("Erasing elements from an empty list does nothing and returns the iterator")
+    {
+        REQUIRE(empty_list.erase_after(empty_list.begin()) == empty_list.begin());
+    }
+    SECTION("Erasing with a list of a single element does nothing")
+    {
+        linear_linked_list<int> singular_list { 1 };
+
+        REQUIRE(*singular_list.erase_after(singular_list.begin()) == 1);
+    }
+    SECTION("Erasing elements from a populated list")
+    { 
+        list.erase_after(list.begin());
+
+        int i = 0;
+        for(auto num : list)
+        {
+            REQUIRE(num == ++i);
+        }
+    }
+}
+
 TEST_CASE("Removing a specific element from a list", "[operations], [remove]")
 {
     linear_linked_list<int> list { 1, 4, 2, 3, 4 };
 
-    SECTION("Remove from a populated list")
+    SECTION("Remove from a populated list returns number of items removed")
     {
         REQUIRE(list.remove(4) == 2);
         REQUIRE(list.size() == 3);


### PR DESCRIPTION
## Proposed changes

Adds a new function, erase_after(), which takes an iterator and removes the next element in the list then returns the iterator. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/AlexanderJDupree/LinkedListsCPP/blob/master/CONTRIBUTING.md) doc
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
